### PR TITLE
feat: `prefer-scope-on-tag-comment`

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,10 +61,11 @@ The rules with the following star ⭐ are included in the configs.
 
 ### @kazupon/eslint-plugin Rules
 
-| Rule ID                                                                                                | Description                                     | Category | Fixable | RECOMMENDED |
-| :----------------------------------------------------------------------------------------------------- | :---------------------------------------------- | :------- | :-----: | :---------: |
-| [@kazupon/enforce-header-comment](https://eslint-plugin.kazupon.dev/rules/enforce-header-comment.html) | Enforce heading the comment in source code file | Comment  |         |     ⭐      |
-| [@kazupon/no-tag-comments](https://eslint-plugin.kazupon.dev/rules/no-tag-comments.html)               | disallow tag comments                           | Comment  |         |             |
+| Rule ID                                                                                                          | Description                                     | Category | Fixable | RECOMMENDED |
+| :--------------------------------------------------------------------------------------------------------------- | :---------------------------------------------- | :------- | :-----: | :---------: |
+| [@kazupon/enforce-header-comment](https://eslint-plugin.kazupon.dev/rules/enforce-header-comment.html)           | Enforce heading the comment in source code file | Comment  |         |     ⭐      |
+| [@kazupon/no-tag-comments](https://eslint-plugin.kazupon.dev/rules/no-tag-comments.html)                         | disallow tag comments                           | Comment  |         |             |
+| [@kazupon/prefer-scope-on-tag-comment](https://eslint-plugin.kazupon.dev/rules/prefer-scope-on-tag-comment.html) | enforce adding a scope to tag comments          | Comment  |         |     ⭐      |
 
 <!--RULES_TABLE_END-->
 

--- a/docs/rules/index.md
+++ b/docs/rules/index.md
@@ -7,9 +7,10 @@ The rules with the following star ⭐ are included in the configs.
 
 ## @kazupon/eslint-plugin Rules
 
-| Rule ID                                                        | Description                                     | Category | Fixable | RECOMMENDED |
-| :------------------------------------------------------------- | :---------------------------------------------- | :------- | :-----: | :---------: |
-| [@kazupon/enforce-header-comment](./enforce-header-comment.md) | Enforce heading the comment in source code file | Comment  |         |     ⭐      |
-| [@kazupon/no-tag-comments](./no-tag-comments.md)               | disallow tag comments                           | Comment  |         |             |
+| Rule ID                                                                  | Description                                     | Category | Fixable | RECOMMENDED |
+| :----------------------------------------------------------------------- | :---------------------------------------------- | :------- | :-----: | :---------: |
+| [@kazupon/enforce-header-comment](./enforce-header-comment.md)           | Enforce heading the comment in source code file | Comment  |         |     ⭐      |
+| [@kazupon/no-tag-comments](./no-tag-comments.md)                         | disallow tag comments                           | Comment  |         |             |
+| [@kazupon/prefer-scope-on-tag-comment](./prefer-scope-on-tag-comment.md) | enforce adding a scope to tag comments          | Comment  |         |     ⭐      |
 
 <!--RULES_TABLE_END-->

--- a/docs/rules/prefer-scope-on-tag-comment.md
+++ b/docs/rules/prefer-scope-on-tag-comment.md
@@ -1,0 +1,128 @@
+---
+pageClass: 'rule-details'
+sidebarDepth: 0
+title: '@kazupon/prefer-scope-on-tag-comment'
+description: 'Enforce adding a scope to tag comments'
+since: 'v0.4.0'
+---
+
+# @kazupon/prefer-scope-on-tag-comment
+
+> Enforce adding a scope to tag comments
+
+## Rule Details
+
+This rule enforces that tag comments (like `TODO`, `FIXME`, etc.) include a scope identifier in parentheses. The scope can be an author name, team name, ticket number, module name, or any other identifier that provides context about the comment.
+
+### Fail
+
+Some examples of **incorrect** code for this rule:
+
+<eslint-code-block>
+
+default `{ tags: ["TODO", "FIXME", "HACK", "BUG", "NOTE"] }` options:
+
+<!-- eslint-skip -->
+
+```js
+/* eslint @kazupon/prefer-scope-on-tag-comment: 'error' */
+
+/* ✗ BAD */
+
+// TODO: This is todo comment
+/* TODO: This is todo comment */
+/**
+ * TODO:
+ * This is todo multiline comment
+ */
+
+// FIXME: Fix this bug
+/* FIXME: Fix this bug */
+
+// BUG: This code has still bug ...
+
+// HACK: Temporary workaround
+```
+
+`{ tags: ['ISSUE'] }` options:
+
+<!-- eslint-skip -->
+
+```js
+/* eslint @kazupon/prefer-scope-on-tag-comment: ['error', { tags: ['ISSUE'] }] */
+
+/* ✗ BAD */
+
+// ISSUE: This code has still issue ...
+
+// TODO: `TODO` tag is not reported
+```
+
+</eslint-code-block>
+
+### Pass
+
+Some examples of **correct** code for this rule:
+
+<eslint-code-block>
+
+default `{ tags: ["TODO", "FIXME", "HACK", "BUG", "NOTE"] }` options:
+
+<!-- eslint-skip -->
+
+```js
+/* eslint @kazupon/prefer-scope-on-tag-comment: 'error' */
+
+/* ✓ GOOD */
+
+// TODO(kazupon): This is todo comment
+/* TODO(auth-team): This is todo comment */
+/**
+ * TODO(next):
+ * This is todo multiline comment
+ */
+
+// FIXME(ISSUE-123): Fix this bug
+/* FIXME(john): Fix this bug */
+
+// BUG(kazupon): This code has still bug ...
+
+// HACK(frontend): Temporary workaround
+// NOTE(security): Check permissions here
+```
+
+`{ tags: ['ISSUE'] }` options:
+
+<!-- eslint-skip -->
+
+```js
+/* eslint @kazupon/prefer-scope-on-tag-comment: ['error', { tags: ['ISSUE'] }] */
+
+/* ✗ BAD */
+
+// ISSUE(kazupon): This code has still issue ...
+
+// TODO: `TODO` tag is not reported
+```
+
+</eslint-code-block>
+
+## 🔧 Options
+
+```json
+{
+  "@kazupon/prefer-scope-on-tag-comment": [
+    "error",
+    {
+      "tags": ["TODO", "FIXME", "HACK", "BUG", "NOTE"]
+    }
+  ]
+}
+```
+
+- **`tags`** (default: `["TODO", "FIXME", "HACK", "BUG", "NOTE"]`) - Array of tag keywords to check
+
+## 🔗 See Also
+
+- [no-warning-comments](https://eslint.org/docs/latest/rules/no-warning-comments)
+- [no-tag-comments](./no-tag-comments.md)

--- a/docs/rules/prefer-scope-on-tag-comment.md
+++ b/docs/rules/prefer-scope-on-tag-comment.md
@@ -98,7 +98,7 @@ default `{ tags: ["TODO", "FIXME", "HACK", "BUG", "NOTE"] }` options:
 ```js
 /* eslint @kazupon/prefer-scope-on-tag-comment: ['error', { tags: ['ISSUE'] }] */
 
-/* ✗ BAD */
+/* ✓ GOOD */
 
 // ISSUE(kazupon): This code has still issue ...
 

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -5,10 +5,12 @@
 
 import enforceHeaderComment from './enforce-header-comment.ts'
 import noTagComments from './no-tag-comments.ts'
+import preferScopeOnTagComment from './prefer-scope-on-tag-comment.ts'
 
 import type { RuleModule } from '../utils/types.ts'
 
 export const rules: Record<string, RuleModule> = {
   'enforce-header-comment': enforceHeaderComment,
-  'no-tag-comments': noTagComments
+  'no-tag-comments': noTagComments,
+  'prefer-scope-on-tag-comment': preferScopeOnTagComment
 }

--- a/src/rules/prefer-scope-on-tag-comment.test.ts
+++ b/src/rules/prefer-scope-on-tag-comment.test.ts
@@ -1,0 +1,305 @@
+/**
+ * @author kazuya kawaguchi (a.k.a. kazupon)
+ * @license MIT
+ */
+
+import { run } from 'eslint-vitest-rule-tester'
+import rule from './prefer-scope-on-tag-comment.ts'
+
+import type { InvalidTestCase, ValidTestCase } from 'eslint-vitest-rule-tester'
+
+const valids: ValidTestCase[] = [
+  {
+    filename: 'index.js',
+    description: 'TODO with scope',
+    code: `// TODO(kazupon): This is todo comment`
+  },
+  {
+    filename: 'index.js',
+    description: 'TODO with scope in block comment',
+    code: `/* TODO(kazupon): This is todo comment */`
+  },
+  {
+    filename: 'index.js',
+    description: 'FIXME with team scope',
+    code: `// FIXME(auth-team): Fix authentication issue`
+  },
+  {
+    filename: 'index.js',
+    description: 'TODO with ticket number scope',
+    code: `// TODO(ISSUE-123): Implement new feature`
+  },
+  {
+    filename: 'index.js',
+    description: 'HACK with module scope',
+    code: `// HACK(frontend): Temporary workaround for rendering`
+  },
+  {
+    filename: 'index.js',
+    description: 'BUG with author scope',
+    code: `// BUG(kazupon): This code has still bug ...`
+  },
+  {
+    filename: 'index.js',
+    description: 'NOTE with scope',
+    code: `// NOTE(security): Check permissions here`
+  },
+  {
+    filename: 'index.js',
+    description: 'no tag comment',
+    code: `// This is just a regular comment`
+  },
+  {
+    filename: 'index.js',
+    description: 'tag in middle of comment',
+    code: `// This is not a TODO at the start`
+  },
+  {
+    filename: 'index.js',
+    description: 'block comment with scope',
+    code: `/**
+ * TODO(john): Implement this function
+ * with proper error handling
+ */`
+  },
+  {
+    filename: 'index.js',
+    description: 'JSDoc style comment with scope',
+    code: `/**
+ * FIXME(alice): Fix memory leak
+ * in the event handler
+ */`
+  },
+  {
+    filename: 'index.js',
+    description: 'custom tags option - only check specified tags',
+    options: [{ tags: ['CUSTOM'] }],
+    code: `// TODO: This TODO is not checked
+// CUSTOM(dev): This custom tag has scope`
+  },
+  {
+    filename: 'index.js',
+    description: 'custom tags option with ISSUE tag',
+    options: [{ tags: ['ISSUE'] }],
+    code: `// ISSUE(kazupon): This code has still issue ...
+// TODO: This TODO is not reported`
+  },
+  {
+    filename: 'index.js',
+    description: 'scope with numbers and special characters',
+    code: `// TODO(user-123_456): Complex scope identifier`
+  },
+  {
+    filename: 'index.js',
+    description: 'scope with dots',
+    code: `// TODO(v1.2.3): Version-based scope`
+  }
+]
+
+const invalids: InvalidTestCase[] = [
+  {
+    filename: 'index.js',
+    description: 'TODO without scope',
+    code: `// TODO: This is todo comment`,
+    errors: [
+      {
+        message: "Tag comment 'TODO' is missing a scope. Use format: TODO(scope)",
+        line: 1,
+        column: 4,
+        endColumn: 8
+      }
+    ]
+  },
+  {
+    filename: 'index.js',
+    description: 'TODO without scope in block comment',
+    code: `/* TODO: This is todo comment */`,
+    errors: [
+      {
+        message: "Tag comment 'TODO' is missing a scope. Use format: TODO(scope)",
+        line: 1,
+        column: 4,
+        endColumn: 8
+      }
+    ]
+  },
+  {
+    filename: 'index.js',
+    description: 'FIXME without scope',
+    code: `// FIXME: Fix this bug`,
+    errors: [
+      {
+        message: "Tag comment 'FIXME' is missing a scope. Use format: FIXME(scope)",
+        line: 1,
+        column: 4,
+        endColumn: 9
+      }
+    ]
+  },
+  {
+    filename: 'index.js',
+    description: 'HACK without scope',
+    code: `// HACK: Temporary workaround`,
+    errors: [
+      {
+        message: "Tag comment 'HACK' is missing a scope. Use format: HACK(scope)",
+        line: 1,
+        column: 4,
+        endColumn: 8
+      }
+    ]
+  },
+  {
+    filename: 'index.js',
+    description: 'BUG without scope',
+    code: `// BUG: This code has still bug ...`,
+    errors: [
+      {
+        message: "Tag comment 'BUG' is missing a scope. Use format: BUG(scope)",
+        line: 1,
+        column: 4,
+        endColumn: 7
+      }
+    ]
+  },
+  {
+    filename: 'index.js',
+    description: 'NOTE without scope',
+    code: `// NOTE: Important information`,
+    errors: [
+      {
+        message: "Tag comment 'NOTE' is missing a scope. Use format: NOTE(scope)",
+        line: 1,
+        column: 4,
+        endColumn: 8
+      }
+    ]
+  },
+  {
+    filename: 'index.js',
+    description: 'tag with no colon',
+    code: `// TODO this should also be detected`,
+    errors: [
+      {
+        message: "Tag comment 'TODO' is missing a scope. Use format: TODO(scope)",
+        line: 1,
+        column: 4,
+        endColumn: 8
+      }
+    ]
+  },
+  {
+    filename: 'index.js',
+    description: 'empty parentheses should be invalid',
+    code: `// TODO(): Empty scope`,
+    errors: [
+      {
+        message: "Tag comment 'TODO' is missing a scope. Use format: TODO(scope)",
+        line: 1,
+        column: 4,
+        endColumn: 8
+      }
+    ]
+  },
+  {
+    filename: 'index.js',
+    description: 'whitespace-only scope should be invalid',
+    code: `// TODO(   ): Whitespace only`,
+    errors: [
+      {
+        message: "Tag comment 'TODO' is missing a scope. Use format: TODO(scope)",
+        line: 1,
+        column: 4,
+        endColumn: 8
+      }
+    ]
+  },
+  {
+    filename: 'index.js',
+    description: 'block comment without scope',
+    code: `/**
+ * TODO:
+ * Implement this function
+ */`,
+    errors: [
+      {
+        message: "Tag comment 'TODO' is missing a scope. Use format: TODO(scope)",
+        line: 2,
+        column: 4,
+        endColumn: 8
+      }
+    ]
+  },
+  {
+    filename: 'index.js',
+    description: 'JSDoc style comment without scope',
+    code: `/**
+ * FIXME:
+ * Fix memory leak
+ */`,
+    errors: [
+      {
+        message: "Tag comment 'FIXME' is missing a scope. Use format: FIXME(scope)",
+        line: 2,
+        column: 4,
+        endColumn: 9
+      }
+    ]
+  },
+  {
+    filename: 'index.js',
+    description: 'multiple tags without scope',
+    code: `// TODO: First task
+// FIXME: Second issue
+/* HACK: Third workaround */`,
+    errors: [
+      {
+        message: "Tag comment 'TODO' is missing a scope. Use format: TODO(scope)",
+        line: 1,
+        column: 4,
+        endColumn: 8
+      },
+      {
+        message: "Tag comment 'FIXME' is missing a scope. Use format: FIXME(scope)",
+        line: 2,
+        column: 4,
+        endColumn: 9
+      },
+      {
+        message: "Tag comment 'HACK' is missing a scope. Use format: HACK(scope)",
+        line: 3,
+        column: 4,
+        endColumn: 8
+      }
+    ]
+  },
+  {
+    filename: 'index.js',
+    description: 'custom tags option',
+    options: [{ tags: ['CUSTOM', 'SPECIAL'] }],
+    code: `// CUSTOM: Custom tag without scope
+// SPECIAL: Special tag without scope
+// TODO: This TODO is not checked`,
+    errors: [
+      {
+        message: "Tag comment 'CUSTOM' is missing a scope. Use format: CUSTOM(scope)",
+        line: 1,
+        column: 4,
+        endColumn: 10
+      },
+      {
+        message: "Tag comment 'SPECIAL' is missing a scope. Use format: SPECIAL(scope)",
+        line: 2,
+        column: 4,
+        endColumn: 11
+      }
+    ]
+  }
+]
+
+run({
+  name: 'prefer-scope-on-tag-comment',
+  rule,
+  valid: valids,
+  invalid: invalids
+})

--- a/src/rules/prefer-scope-on-tag-comment.ts
+++ b/src/rules/prefer-scope-on-tag-comment.ts
@@ -1,0 +1,202 @@
+/**
+ * @author kazuya kawaguchi (a.k.a. kazupon)
+ * @license MIT
+ */
+
+import { createRule } from '../utils/rule.ts'
+
+import type { Comment } from '../utils/types.ts'
+
+type Options = {
+  tags: string[]
+}
+
+const DEFAULT_TAGS = ['TODO', 'FIXME', 'HACK', 'BUG', 'NOTE']
+
+/**
+ * Remove JSDoc asterisk prefix if present
+ */
+function stripJSDocPrefix(line: string): string {
+  const trimmed = line.trim()
+  return trimmed.startsWith('*') ? trimmed.slice(1).trim() : trimmed
+}
+
+const rule: ReturnType<typeof createRule> = createRule({
+  name: 'prefer-scope-on-tag-comment',
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description: 'enforce adding a scope to tag comments',
+      category: 'Comment',
+      recommended: true,
+      defaultSeverity: 'warn'
+    },
+    messages: {
+      missingScope: "Tag comment '{{tag}}' is missing a scope. Use format: {{tag}}(scope)"
+    },
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          tags: {
+            type: 'array',
+            items: {
+              type: 'string'
+            },
+            minItems: 1,
+            uniqueItems: true
+          }
+        },
+        additionalProperties: false
+      }
+    ]
+  },
+  create(ctx) {
+    const options: Options = ctx.options[0] || { tags: DEFAULT_TAGS }
+    const tags = options.tags || DEFAULT_TAGS
+    const sourceCode = ctx.sourceCode
+
+    /**
+     * Check if the text starts with a tag and return tag info
+     */
+    function getTagInfo(text: string): { tag: string; hasScope: boolean } | null {
+      for (const tag of tags) {
+        if (text.startsWith(tag)) {
+          const afterTag = text.slice(tag.length)
+
+          // Check if tag is followed by a scope in parentheses
+          if (afterTag.startsWith('(')) {
+            const closingParenIndex = afterTag.indexOf(')')
+            if (closingParenIndex > 0) {
+              // Has scope if there's content between parentheses
+              const scope = afterTag.slice(1, closingParenIndex).trim()
+              return { tag, hasScope: scope.length > 0 }
+            }
+            // If we have opening paren but no closing or empty scope, it's invalid
+            return { tag, hasScope: false }
+          }
+
+          // Check if tag is followed by valid delimiter without scope
+          if (afterTag === '' || afterTag.startsWith(':') || afterTag.startsWith(' ')) {
+            return { tag, hasScope: false }
+          }
+        }
+      }
+      return null
+    }
+
+    /**
+     * Report a missing scope violation
+     */
+    function reportMissingScope(
+      comment: Comment,
+      tag: string,
+      loc?: { line: number; column: number }
+    ) {
+      if (loc && comment.loc) {
+        // For block comments, report specific location
+        ctx.report({
+          messageId: 'missingScope',
+          data: { tag },
+          loc: {
+            start: {
+              line: loc.line,
+              column: loc.column
+            },
+            end: {
+              line: loc.line,
+              column: loc.column + tag.length
+            }
+          }
+        })
+      } else {
+        // For line comments, report whole comment
+        ctx.report({
+          messageId: 'missingScope',
+          data: { tag },
+          loc: comment.loc!
+        })
+      }
+    }
+
+    /**
+     * Check a comment for missing scope
+     */
+    function checkComment(comment: Comment) {
+      const { value, type } = comment
+
+      if (type === 'Line') {
+        const tagInfo = getTagInfo(value.trim())
+        if (tagInfo && !tagInfo.hasScope) {
+          // Calculate the exact position of the tag in the line comment
+          const tagIndex = value.indexOf(tagInfo.tag)
+          if (tagIndex !== -1) {
+            reportMissingScope(comment, tagInfo.tag, {
+              line: comment.loc!.start.line,
+              column: comment.loc!.start.column + 2 + tagIndex // +2 for "//"
+            })
+          }
+        }
+        return
+      }
+
+      // Block comment
+      const lines = value.split('\n')
+      let currentLine = comment.loc!.start.line
+
+      for (const [i, line] of lines.entries()) {
+        const trimmedLine = line.trim()
+
+        // Skip empty lines
+        if (!trimmedLine) {
+          currentLine++
+          continue
+        }
+
+        // Remove JSDoc prefix if present
+        const contentToCheck = stripJSDocPrefix(line)
+        const tagInfo = getTagInfo(contentToCheck)
+
+        if (tagInfo && !tagInfo.hasScope) {
+          // For the first line, handle the comment opener
+          if (i === 0) {
+            // For single line block comments like /* TODO: ... */
+            // We need to account for the position within the comment
+            const tagIndexInValue = value.indexOf(tagInfo.tag)
+            if (tagIndexInValue !== -1) {
+              // Add 2 for /* and then the position of the tag
+              reportMissingScope(comment, tagInfo.tag, {
+                line: currentLine,
+                column: comment.loc!.start.column + 2 + tagIndexInValue
+              })
+              break
+            }
+          } else {
+            // For subsequent lines, find where the tag starts
+            const tagIndex = line.indexOf(tagInfo.tag)
+            if (tagIndex !== -1) {
+              reportMissingScope(comment, tagInfo.tag, {
+                line: currentLine,
+                column: tagIndex
+              })
+              break
+            }
+          }
+        }
+
+        currentLine++
+      }
+    }
+
+    return {
+      Program() {
+        const comments = sourceCode.getAllComments()
+        for (const comment of comments) {
+          checkComment(comment)
+        }
+      }
+    }
+  }
+})
+
+export default rule


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/kazupon/eslint-plugin/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

resolve #6
 
### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new rule that enforces adding a scope to tag comments such as TODO, FIXME, HACK, BUG, and NOTE.
- **Documentation**
  - Updated documentation to include the new rule with detailed usage instructions, configuration options, and examples.
- **Tests**
  - Added comprehensive tests to ensure the new rule correctly validates scoped tag comments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->