### PR TITLE
feat: prefer-inline-code-words-comments for comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ The rules with the following star ⭐ are included in the configs.
 | :--------------------------------------------------------------------------------------------------------------------------- | :------------------------------------------------------------ | :------- | :-----: | :---------: |
 | [@kazupon/enforce-header-comment](https://eslint-plugin.kazupon.dev/rules/enforce-header-comment.html)                       | Enforce heading the comment in source code file               | Comment  |         |     ⭐      |
 | [@kazupon/no-tag-comments](https://eslint-plugin.kazupon.dev/rules/no-tag-comments.html)                                     | disallow tag comments                                         | Comment  |         |     ⭐      |
-| [@kazupon/prefer-inline-code-words-comments](https://eslint-plugin.kazupon.dev/rules/prefer-inline-code-words-comments.html) | enforce the use of inline code for specific words on comments | Comment  |   🔧    |             |
+| [@kazupon/prefer-inline-code-words-comments](https://eslint-plugin.kazupon.dev/rules/prefer-inline-code-words-comments.html) | enforce the use of inline code for specific words on comments | Comment  |   🔧    |     ⭐      |
 | [@kazupon/prefer-scope-on-tag-comment](https://eslint-plugin.kazupon.dev/rules/prefer-scope-on-tag-comment.html)             | enforce adding a scope to tag comments                        | Comment  |         |     ⭐      |
 
 <!--RULES_TABLE_END-->

--- a/README.md
+++ b/README.md
@@ -61,11 +61,12 @@ The rules with the following star ⭐ are included in the configs.
 
 ### @kazupon/eslint-plugin Rules
 
-| Rule ID                                                                                                          | Description                                     | Category | Fixable | RECOMMENDED |
-| :--------------------------------------------------------------------------------------------------------------- | :---------------------------------------------- | :------- | :-----: | :---------: |
-| [@kazupon/enforce-header-comment](https://eslint-plugin.kazupon.dev/rules/enforce-header-comment.html)           | Enforce heading the comment in source code file | Comment  |         |     ⭐      |
-| [@kazupon/no-tag-comments](https://eslint-plugin.kazupon.dev/rules/no-tag-comments.html)                         | disallow tag comments                           | Comment  |         |     ⭐      |
-| [@kazupon/prefer-scope-on-tag-comment](https://eslint-plugin.kazupon.dev/rules/prefer-scope-on-tag-comment.html) | enforce adding a scope to tag comments          | Comment  |         |     ⭐      |
+| Rule ID                                                                                                                      | Description                                                   | Category | Fixable | RECOMMENDED |
+| :--------------------------------------------------------------------------------------------------------------------------- | :------------------------------------------------------------ | :------- | :-----: | :---------: |
+| [@kazupon/enforce-header-comment](https://eslint-plugin.kazupon.dev/rules/enforce-header-comment.html)                       | Enforce heading the comment in source code file               | Comment  |         |     ⭐      |
+| [@kazupon/no-tag-comments](https://eslint-plugin.kazupon.dev/rules/no-tag-comments.html)                                     | disallow tag comments                                         | Comment  |         |     ⭐      |
+| [@kazupon/prefer-inline-code-words-comments](https://eslint-plugin.kazupon.dev/rules/prefer-inline-code-words-comments.html) | enforce the use of inline code for specific words on comments | Comment  |   🔧    |             |
+| [@kazupon/prefer-scope-on-tag-comment](https://eslint-plugin.kazupon.dev/rules/prefer-scope-on-tag-comment.html)             | enforce adding a scope to tag comments                        | Comment  |         |     ⭐      |
 
 <!--RULES_TABLE_END-->
 

--- a/docs/rules/index.md
+++ b/docs/rules/index.md
@@ -7,10 +7,11 @@ The rules with the following star ⭐ are included in the configs.
 
 ## @kazupon/eslint-plugin Rules
 
-| Rule ID                                                                  | Description                                     | Category | Fixable | RECOMMENDED |
-| :----------------------------------------------------------------------- | :---------------------------------------------- | :------- | :-----: | :---------: |
-| [@kazupon/enforce-header-comment](./enforce-header-comment.md)           | Enforce heading the comment in source code file | Comment  |         |     ⭐      |
-| [@kazupon/no-tag-comments](./no-tag-comments.md)                         | disallow tag comments                           | Comment  |         |     ⭐      |
-| [@kazupon/prefer-scope-on-tag-comment](./prefer-scope-on-tag-comment.md) | enforce adding a scope to tag comments          | Comment  |         |     ⭐      |
+| Rule ID                                                                              | Description                                                   | Category | Fixable | RECOMMENDED |
+| :----------------------------------------------------------------------------------- | :------------------------------------------------------------ | :------- | :-----: | :---------: |
+| [@kazupon/enforce-header-comment](./enforce-header-comment.md)                       | Enforce heading the comment in source code file               | Comment  |         |     ⭐      |
+| [@kazupon/no-tag-comments](./no-tag-comments.md)                                     | disallow tag comments                                         | Comment  |         |     ⭐      |
+| [@kazupon/prefer-inline-code-words-comments](./prefer-inline-code-words-comments.md) | enforce the use of inline code for specific words on comments | Comment  |   🔧    |             |
+| [@kazupon/prefer-scope-on-tag-comment](./prefer-scope-on-tag-comment.md)             | enforce adding a scope to tag comments                        | Comment  |         |     ⭐      |
 
 <!--RULES_TABLE_END-->

--- a/docs/rules/index.md
+++ b/docs/rules/index.md
@@ -11,7 +11,7 @@ The rules with the following star ⭐ are included in the configs.
 | :----------------------------------------------------------------------------------- | :------------------------------------------------------------ | :------- | :-----: | :---------: |
 | [@kazupon/enforce-header-comment](./enforce-header-comment.md)                       | Enforce heading the comment in source code file               | Comment  |         |     ⭐      |
 | [@kazupon/no-tag-comments](./no-tag-comments.md)                                     | disallow tag comments                                         | Comment  |         |     ⭐      |
-| [@kazupon/prefer-inline-code-words-comments](./prefer-inline-code-words-comments.md) | enforce the use of inline code for specific words on comments | Comment  |   🔧    |             |
+| [@kazupon/prefer-inline-code-words-comments](./prefer-inline-code-words-comments.md) | enforce the use of inline code for specific words on comments | Comment  |   🔧    |     ⭐      |
 | [@kazupon/prefer-scope-on-tag-comment](./prefer-scope-on-tag-comment.md)             | enforce adding a scope to tag comments                        | Comment  |         |     ⭐      |
 
 <!--RULES_TABLE_END-->

--- a/docs/rules/prefer-inline-code-words-comments.md
+++ b/docs/rules/prefer-inline-code-words-comments.md
@@ -121,4 +121,4 @@ This rule was introduced in `@kazupon/eslint-plugin` v0.6.0
 ## Implementation
 
 - [Rule source](https://github.com/kazupon/eslint-plugin/blob/main/src/rules/prefer-inline-code-words-comments.ts)
-- [Test source](https://github.com/kazupon/eslint-plugin/blob/main/src/rules/prefer-inline-code-words-comments.ts)
+- [Test source](https://github.com/kazupon/eslint-plugin/blob/main/src/rules/prefer-inline-code-words-comments.test.ts)

--- a/docs/rules/prefer-inline-code-words-comments.md
+++ b/docs/rules/prefer-inline-code-words-comments.md
@@ -1,0 +1,124 @@
+---
+pageClass: 'rule-details'
+sidebarDepth: 0
+title: '@kazupon/prefer-inline-code-words-comments'
+description: 'enforce the use of inline code for specific words on comments'
+since: 'v0.6.0'
+---
+
+# @kazupon/prefer-inline-code-words-comments
+
+> enforce the use of inline code for specific words on comments
+
+- 🔧 The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
+
+## Rule Details
+
+This rule enforces that specific words or phrases are always wrapped in inline code (backticks) when they appear in Comments. This is useful for:
+
+- Ensuring technical terms, API names, or function names are consistently formatted as code
+- Maintaining consistent styling for programming-related terminology
+- Automatically applying code formatting to specified words
+
+### Fail
+
+Some examples of **incorrect** code for this rule:
+
+<eslint-code-block>
+
+`{ words: ["console.log", "fetch"] }` options:
+
+<!-- eslint-skip -->
+
+```js
+/* eslint @kazupon/prefer-inline-code-words-comments: ['error', { words: ['console.log', 'fetch'] }] */
+
+/* ✗ BAD */
+
+// you can output with using console.log
+console.log('hello world!')
+
+/* load user data via fetch */
+const data = await fetch('https://example.com/api/users/1')
+
+/**
+ * Get a blog article.
+ *
+ * This API is used by fetch internally
+ *
+ * @params id - An blog ID
+ * @returns A blog article data
+ */
+export function getBlogArticle(id) {
+  // something logic ...
+}
+```
+
+</eslint-code-block>
+
+### Pass
+
+Some examples of **correct** code for this rule:
+
+<eslint-code-block>
+
+`{ words: ["console.log", "fetch"] }` options:
+
+<!-- eslint-skip -->
+
+```js
+/* eslint @kazupon/prefer-inline-code-words-comments: ['error', { words: ['console.log', 'fetch'] }] */
+
+/* ✓ GOOD */
+
+// you can output with using `console.log`
+console.log('hello world!')
+
+/* load user data via `fetch` */
+const data = await fetch('https://example.com/api/users/1')
+
+/**
+ * Get a blog article.
+ *
+ * This API is used by `fetch` internally
+ *
+ * @params id - An blog ID
+ * @returns A blog article data
+ */
+export function getBlogArticle(id) {
+  // something logic ...
+}
+```
+
+</eslint-code-block>
+
+## 🔧 Options
+
+This rule requires configuration of the words that should be wrapped in inline code.
+
+```json
+{
+  "@kazupon/prefer-inline-code-words-comments": [
+    "error",
+    {
+      "words": ["console.log", "fetch"]
+    }
+  ]
+}
+```
+
+- `words` (required):
+  - Strings representing the words that should always be wrapped in inline code when they appear in comments.
+
+## Related rules
+
+Nothing.
+
+## Version
+
+This rule was introduced in `@kazupon/eslint-plugin` v0.6.0
+
+## Implementation
+
+- [Rule source](https://github.com/kazupon/eslint-plugin/blob/main/src/rules/prefer-inline-code-words-comments.ts)
+- [Test source](https://github.com/kazupon/eslint-plugin/blob/main/src/rules/prefer-inline-code-words-comments.ts)

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -5,6 +5,7 @@
 
 import enforceHeaderComment from './enforce-header-comment.ts'
 import noTagComments from './no-tag-comments.ts'
+import preferInlineCodeWordsComments from './prefer-inline-code-words-comments.ts'
 import preferScopeOnTagComment from './prefer-scope-on-tag-comment.ts'
 
 import type { RuleModule } from '../utils/types.ts'
@@ -12,5 +13,6 @@ import type { RuleModule } from '../utils/types.ts'
 export const rules: Record<string, RuleModule> = {
   'enforce-header-comment': enforceHeaderComment,
   'no-tag-comments': noTagComments,
-  'prefer-scope-on-tag-comment': preferScopeOnTagComment
+  'prefer-scope-on-tag-comment': preferScopeOnTagComment,
+  'prefer-inline-code-words-comments': preferInlineCodeWordsComments
 }

--- a/src/rules/prefer-inline-code-words-comments.test.ts
+++ b/src/rules/prefer-inline-code-words-comments.test.ts
@@ -1,0 +1,238 @@
+/**
+ * @author kazuya kawaguchi (a.k.a. kazupon)
+ * @license MIT
+ */
+
+import { run } from 'eslint-vitest-rule-tester'
+import rule from './prefer-inline-code-words-comments.ts'
+
+import type { InvalidTestCase, ValidTestCase } from 'eslint-vitest-rule-tester'
+
+const valids: ValidTestCase[] = [
+  {
+    filename: 'index.js',
+    description: 'no options provided - no checks performed',
+    code: '// you can output with using console.log'
+  },
+  {
+    filename: 'index.js',
+    description: 'line comment with inline code already present',
+    options: [{ words: ['console.log'] }],
+    code: '// you can output with using `console.log`'
+  },
+  {
+    filename: 'index.js',
+    description: 'block comment with inline code already present',
+    options: [{ words: ['fetch'] }],
+    code: '/* load user data via `fetch` */'
+  },
+  {
+    filename: 'index.js',
+    description: 'jsdoc style comment with inline code already present',
+    options: [{ words: ['fetch'] }],
+    code: `/**
+ * Get a blog article.
+ *
+ * This API is used by \`fetch\` internally
+ *
+ * @params id - An blog ID
+ * @returns A blog article data
+ */`
+  },
+  {
+    filename: 'index.js',
+    description: 'multiple words, all wrapped in inline code',
+    options: [{ words: ['console.log', 'fetch'] }],
+    code: `// you can output with using \`console.log\`
+console.log('hello world!')
+
+/* load user data via \`fetch\` */
+const data = await fetch('https://example.com/api/users/1')`
+  },
+  {
+    filename: 'index.js',
+    description: 'word not in the list is not checked',
+    options: [{ words: ['console.log'] }],
+    code: '// use fetch to load data'
+  },
+  {
+    filename: 'index.js',
+    description: 'word as part of larger word is not matched',
+    options: [{ words: ['log'] }],
+    code: '// use logging to output'
+  },
+  {
+    filename: 'index.js',
+    description: 'word as standalone is matched',
+    options: [{ words: ['log'] }],
+    code: '// use `log` to output'
+  },
+  {
+    filename: 'index.js',
+    description: 'case sensitive matching',
+    options: [{ words: ['fetch'] }],
+    code: '// use FETCH to load data'
+  }
+]
+
+const invalids: InvalidTestCase[] = [
+  {
+    filename: 'index.js',
+    description: 'line comment missing inline code',
+    options: [{ words: ['console.log'] }],
+    code: '// you can output with using console.log',
+    output: '// you can output with using `console.log`',
+    errors: [
+      {
+        message: 'The word "console.log" should be wrapped in inline code',
+        line: 1,
+        column: 30,
+        endColumn: 41
+      }
+    ]
+  },
+  {
+    filename: 'index.js',
+    description: 'block comment missing inline code',
+    options: [{ words: ['fetch'] }],
+    code: '/* load user data via fetch */',
+    output: '/* load user data via `fetch` */',
+    errors: [
+      {
+        message: 'The word "fetch" should be wrapped in inline code',
+        line: 1,
+        column: 23,
+        endColumn: 28
+      }
+    ]
+  },
+  {
+    filename: 'index.js',
+    description: 'jsdoc style comment missing inline code',
+    options: [{ words: ['fetch'] }],
+    code: `/**
+ * Get a blog article.
+ *
+ * This API is used by fetch internally
+ *
+ * @params id - An blog ID
+ * @returns A blog article data
+ */`,
+    output: `/**
+ * Get a blog article.
+ *
+ * This API is used by \`fetch\` internally
+ *
+ * @params id - An blog ID
+ * @returns A blog article data
+ */`,
+    errors: [
+      {
+        message: 'The word "fetch" should be wrapped in inline code',
+        line: 4,
+        column: 24,
+        endColumn: 29
+      }
+    ]
+  },
+  {
+    filename: 'index.js',
+    description: 'multiple occurrences in single comment',
+    options: [{ words: ['fetch'] }],
+    code: '// use fetch to load data, fetch is async',
+    output: '// use `fetch` to load data, `fetch` is async',
+    errors: [
+      {
+        message: 'The word "fetch" should be wrapped in inline code',
+        line: 1,
+        column: 8,
+        endColumn: 13
+      },
+      {
+        message: 'The word "fetch" should be wrapped in inline code',
+        line: 1,
+        column: 28,
+        endColumn: 33
+      }
+    ]
+  },
+  {
+    filename: 'index.js',
+    description: 'multiple words missing inline code',
+    options: [{ words: ['console.log', 'fetch'] }],
+    code: `// you can output with using console.log
+console.log('hello world!')
+
+/* load user data via fetch */
+const data = await fetch('https://example.com/api/users/1')`,
+    output: `// you can output with using \`console.log\`
+console.log('hello world!')
+
+/* load user data via \`fetch\` */
+const data = await fetch('https://example.com/api/users/1')`,
+    errors: [
+      {
+        message: 'The word "console.log" should be wrapped in inline code',
+        line: 1,
+        column: 30,
+        endColumn: 41
+      },
+      {
+        message: 'The word "fetch" should be wrapped in inline code',
+        line: 4,
+        column: 23,
+        endColumn: 28
+      }
+    ]
+  },
+  {
+    filename: 'index.js',
+    description: 'multiline comment with missing inline code',
+    options: [{ words: ['console.log', 'fetch'] }],
+    code: `/**
+ * Get a blog article.
+ *
+ * This API is used by fetch internally
+ * and outputs results with console.log
+ *
+ * @params id - An blog ID
+ * @returns A blog article data
+ */
+export function getBlogArticle(id) {
+  // something logic ...
+}`,
+    output: `/**
+ * Get a blog article.
+ *
+ * This API is used by \`fetch\` internally
+ * and outputs results with \`console.log\`
+ *
+ * @params id - An blog ID
+ * @returns A blog article data
+ */
+export function getBlogArticle(id) {
+  // something logic ...
+}`,
+    errors: [
+      {
+        message: 'The word "fetch" should be wrapped in inline code',
+        line: 4,
+        column: 24,
+        endColumn: 29
+      },
+      {
+        message: 'The word "console.log" should be wrapped in inline code',
+        line: 5,
+        column: 29,
+        endColumn: 40
+      }
+    ]
+  }
+]
+
+run({
+  name: 'prefer-inline-code-words-comments',
+  rule,
+  valid: valids,
+  invalid: invalids
+})

--- a/src/rules/prefer-inline-code-words-comments.ts
+++ b/src/rules/prefer-inline-code-words-comments.ts
@@ -108,7 +108,6 @@ const rule: ReturnType<typeof createRule> = createRule({
           } else {
             // Block comment
             const beforeMatch = value.slice(0, Math.max(0, index))
-            // const lines = value.split('\n')
             const beforeLines = beforeMatch.split('\n')
             const lineIndex = beforeLines.length - 1
             line = comment.loc!.start.line + lineIndex

--- a/src/rules/prefer-inline-code-words-comments.ts
+++ b/src/rules/prefer-inline-code-words-comments.ts
@@ -1,0 +1,159 @@
+/**
+ * @author kazuya kawaguchi (a.k.a. kazupon)
+ * @license MIT
+ */
+
+import { createRule } from '../utils/rule.ts'
+
+import type { Comment } from '../utils/types.ts'
+
+type Options = {
+  words: string[]
+}
+
+/**
+ * Check if a word is already wrapped in inline code
+ *
+ * @param text - The text to check
+ * @param index - The index of the word in the text
+ * @param word - The word to check
+ * @returns True if the word is already wrapped in backticks
+ */
+function isWrappedInBackticks(text: string, index: number, word: string): boolean {
+  const beforeIndex = index - 1
+  const afterIndex = index + word.length
+  return (
+    beforeIndex >= 0 &&
+    afterIndex < text.length &&
+    text[beforeIndex] === '`' &&
+    text[afterIndex] === '`'
+  )
+}
+
+const rule: ReturnType<typeof createRule> = createRule({
+  name: 'prefer-inline-code-words-comments',
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description: 'enforce the use of inline code for specific words on comments',
+      category: 'Comment',
+      recommended: false,
+      defaultSeverity: 'error'
+    },
+    fixable: 'code',
+    messages: {
+      missingInlineCode: 'The word "{{word}}" should be wrapped in inline code'
+    },
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          words: {
+            type: 'array',
+            items: {
+              type: 'string'
+            },
+            minItems: 1,
+            uniqueItems: true
+          }
+        },
+        required: ['words'],
+        additionalProperties: false
+      }
+    ]
+  },
+  create(ctx) {
+    const options: Options = ctx.options[0]
+    if (!options || !options.words || options.words.length === 0) {
+      return {}
+    }
+
+    const words = options.words
+    const sourceCode = ctx.sourceCode
+
+    /**
+     * Check a comment for words that should be wrapped in inline code
+     *
+     * @param comment - The comment node to check
+     */
+    function checkComment(comment: Comment) {
+      const { value, type } = comment
+
+      for (const word of words) {
+        // Escape special regex characters in the word
+        const escapedWord = word.replaceAll(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`)
+
+        // Create regex with word boundaries
+        // For words with dots (like console.log), we still use word boundaries
+        // but the dots are escaped so they match literally
+        const regex = new RegExp(`\\b${escapedWord}\\b`, 'g')
+
+        let match
+
+        while ((match = regex.exec(value)) !== null) {
+          const index = match.index
+
+          // Check if the word is already wrapped in backticks
+          if (isWrappedInBackticks(value, index, word)) {
+            continue
+          }
+
+          // Calculate position based on comment type
+          let line: number
+          let column: number
+
+          if (type === 'Line') {
+            line = comment.loc!.start.line
+            column = comment.loc!.start.column + 2 + index // +2 for "//"
+          } else {
+            // Block comment
+            const beforeMatch = value.slice(0, Math.max(0, index))
+            // const lines = value.split('\n')
+            const beforeLines = beforeMatch.split('\n')
+            const lineIndex = beforeLines.length - 1
+            line = comment.loc!.start.line + lineIndex
+
+            if (lineIndex === 0) {
+              // First line of block comment
+              column = comment.loc!.start.column + 2 + beforeMatch.length // +2 for "/*"
+            } else {
+              // For subsequent lines in block comments
+              // We need to find the position in the specific line
+              const allLines = value.split('\n')
+              const currentLine = allLines[lineIndex]
+              const wordIndexInLine = currentLine.indexOf(word)
+
+              // The column matches calculateTagLocation: just the index in the line
+              column = wordIndexInLine
+            }
+          }
+
+          ctx.report({
+            messageId: 'missingInlineCode',
+            data: { word },
+            loc: {
+              start: { line, column },
+              end: { line, column: column + word.length }
+            },
+            fix(fixer) {
+              const startOffset = comment.range![0] + 2 + index // +2 for comment start
+              const endOffset = startOffset + word.length
+              return fixer.replaceTextRange([startOffset, endOffset], `\`${word}\``)
+            }
+          })
+        }
+      }
+    }
+
+    return {
+      Program() {
+        const comments = sourceCode.getAllComments()
+        for (const comment of comments) {
+          checkComment(comment)
+        }
+      }
+    }
+  }
+})
+
+export default rule

--- a/src/rules/prefer-inline-code-words-comments.ts
+++ b/src/rules/prefer-inline-code-words-comments.ts
@@ -117,13 +117,11 @@ const rule: ReturnType<typeof createRule> = createRule({
               column = comment.loc!.start.column + 2 + beforeMatch.length // +2 for "/*"
             } else {
               // For subsequent lines in block comments
-              // We need to find the position in the specific line
-              const allLines = value.split('\n')
-              const currentLine = allLines[lineIndex]
-              const wordIndexInLine = currentLine.indexOf(word)
-
-              // The column matches calculateTagLocation: just the index in the line
-              column = wordIndexInLine
+              const columnInValue =
+                beforeMatch.length -
+                beforeLines.slice(0, -1).join('\n').length -
+                (lineIndex > 0 ? 1 : 0)
+              column = columnInValue
             }
           }
 

--- a/src/rules/prefer-inline-code-words-comments.ts
+++ b/src/rules/prefer-inline-code-words-comments.ts
@@ -37,7 +37,7 @@ const rule: ReturnType<typeof createRule> = createRule({
     docs: {
       description: 'enforce the use of inline code for specific words on comments',
       category: 'Comment',
-      recommended: false,
+      recommended: true,
       defaultSeverity: 'error'
     },
     fixable: 'code',


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/kazupon/eslint-plugin/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a new rule that enforces the use of inline code formatting (backticks) for specified words in comments.
* **Documentation**
  * Updated the rules table to include the new rule and improved table formatting for readability.
  * Added detailed documentation for the new rule, including usage examples and configuration options.
* **Tests**
  * Added comprehensive tests to verify correct detection and autofix behavior for the new rule.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->